### PR TITLE
Fix training and test data loading: remove duplicate code and fix arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
 
     '''dataset preparation'''
-    clean_train_data, clean_test_data = utils.load_cifar10_data(args.data_path,trans['aug'],trans['clean'])
+    clean_train_data, clean_test_data = utils.load_cifar10_data(args.data_path, transform_train=trans['aug'], transform_test=trans['clean'])
 
     if args.pert == 'OPS':
         datapack = {'image': clean_train_data.data / 255,

--- a/main.py
+++ b/main.py
@@ -55,8 +55,6 @@ if __name__ == '__main__':
                                         ])
             }
 
-    clean_train_data, clean_test_data = utils.load_cifar10_data(args.data_path,trans['aug'],trans['clean'])
-
     if args.data_aug == 'Standard':
         trans['aug'] = transforms.Compose([transforms.RandomHorizontalFlip(),
                                         transforms.RandomCrop(32, 4),


### PR DESCRIPTION
# Summary
This PR addresses 1 severe issue and 1 minor issue in the data loading code that were causing incorrect behaviour.
# Changes Made
1. Removed duplicate `utils.load_cifar10_data(...)` call
2. Fix Function Arguments
**Issue**: Function was called with positional args instead of keyword args
**Problem**: `utils.load_cifar10_data` takes in 4 arguments, and the second argument is `download` (boolean). However, it was called with only 3 arguments in `main.py`, so  `trans['aug']` was being passed as `download` parameter, and `trans['clean']` as `transform_train`.
**Fix**: Updated to use explicit keywords: `transform_train=trans['aug'], transform_test=trans['clean']`
# Impact
✅ Data augmentation now applies correctly
✅ Eliminates redundant data loading
✅ No breaking changes
# Verify
To verify that these changes actually fix the problem, try running
```console
chmod u+x run.sh
./run.sh
```